### PR TITLE
Don't report duplicate favro cards

### DIFF
--- a/lib/favro/plugin.rb
+++ b/lib/favro/plugin.rb
@@ -105,7 +105,7 @@ module Danger
         matches += item.scan(@issue_pattern).flatten
       end
 
-      matches.uniq.collect(&:upcase)
+      matches.collect(&:upcase).uniq
     end
 
     def render_table(cards)

--- a/spec/favro_spec.rb
+++ b/spec/favro_spec.rb
@@ -66,6 +66,16 @@ module Danger
         expect(@dangerfile.status_report[:markdowns][0].message.delete("\n")).to eq(comment_table)
       end
 
+      it "doesn't report duplicate favro cards" do
+        testing_pr_title(@dangerfile, "test-123")
+        testing_changes(@dangerfile, added_text: "//TEST-123")
+        testing_changes(@dangerfile, added_text: "//TesT-123")
+        testing_api_request("TEST-123")
+
+        @my_plugin.check
+        expect(@dangerfile.status_report[:markdowns][0].message.delete("\n")).to eq(comment_table)
+      end
+
       context "on GitHub PR" do
         it "detects Favro card in PR title" do
           testing_pr_title(@dangerfile, "TEST-123")


### PR DESCRIPTION
Because it did a `uniq` before the casing normalization, card duplicates could get reported.